### PR TITLE
Ignore changes to AMI ID because the EC2 instance should be cycled wh…

### DIFF
--- a/modules/jira/jira.tf
+++ b/modules/jira/jira.tf
@@ -14,6 +14,12 @@ resource "aws_launch_configuration" "jira_host_lc" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      # Ignore changes to AMI ID because the EC2 instance should be cycled when tested
+      # instead of when AWS update the image as this may cause an outage.
+      # On the map is use ing ECS Fargate - this ASG and AMI are temporary.
+      image_id,
+    ]
   }
 }
 


### PR DESCRIPTION
…en tested

instead of when AWS update the image as this may cause an outage.
On the map is use ing ECS Fargate - this ASG and AMI are temporary.