### PR TITLE
NIT-211 autostop-<env> tag to Phase1

### DIFF
--- a/jira_rds_cluster/main.tf
+++ b/jira_rds_cluster/main.tf
@@ -59,7 +59,11 @@ module "jira_db" {
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.jira_db.id
   enabled_cloudwatch_logs_exports = ["postgresql"]
 
-  tags = var.tags
+  tags = merge(var.tags,
+    {
+      "autostop-${var.environment_type}" = "Phase1"
+    }
+  )
 
   backup_retention_period = 14 #days
   # backtrack_window        = 86400 # seconds = 24 hours # not applicable in this type of cluster

--- a/jira_rds_cluster/variables.tf
+++ b/jira_rds_cluster/variables.tf
@@ -3,7 +3,7 @@ variable "environment_name" {
 }
 
 variable "environment_type" {
-  type = string
+  type        = string
   description = "Environment type to be used as a unique identifier for resources - eg. dev or pre-prod"
 }
 

--- a/jira_rds_cluster/variables.tf
+++ b/jira_rds_cluster/variables.tf
@@ -2,6 +2,11 @@ variable "environment_name" {
   type = string
 }
 
+variable "environment_type" {
+  type = string
+  description = "Environment type to be used as a unique identifier for resources - eg. dev or pre-prod"
+}
+
 variable "tags" {
   type = map(string)
 }


### PR DESCRIPTION
Phase1 occurs 1st when starting services, and 2nd when stopping. Original values meant that if auto start/stop was enabled in the environment, RDS databases could be shut down when apps are still running, which could result in data loss.
Setting Phase1 across all environments does not mean that databases will be shut down over night. RDS DB schedules are disabled at the lambda level